### PR TITLE
Fix: Incorrect argument label in call viewController

### DIFF
--- a/ios/Classes/SwiftFlutterSocialContentSharePlugin.swift
+++ b/ios/Classes/SwiftFlutterSocialContentSharePlugin.swift
@@ -108,7 +108,7 @@ public class SwiftFlutterSocialContentSharePlugin: NSObject, FlutterPlugin, Shar
             }
             if let flutterAppDelegate = UIApplication.shared.delegate as? FlutterAppDelegate {
                 let shareDialog = ShareDialog(
-                    fromViewController: flutterAppDelegate.window.rootViewController,
+                    viewController: flutterAppDelegate.window.rootViewController,
                     content: shareContent,
                     delegate: self
                 )


### PR DESCRIPTION
When run your package in this version and platform, i got the error:
```dart
Incorrect argument label in call (have 'fromViewController:content:delegate:', expected 'viewController:content:delegate:')
```
Flutter Version: 2.5.3 and 2.8
Platform: iOS 15

I think you're not updating your package to support this version. So i change 'fromViewController' into 'viewController' and the problem fixed.

Thanks, i hope you will merge my PR!